### PR TITLE
fix: Remove env from next.confg

### DIFF
--- a/apps/nextjs-contentful/next.config.js
+++ b/apps/nextjs-contentful/next.config.js
@@ -8,16 +8,6 @@ const { composePlugins, withNx } = require('@nx/next');
  **/
 const nextConfig = {
   transpilePackages: ['@cmpsr/nextjs-contentful-renderer'],
-  env: {
-    CONTENTFUL_SPACE_ID: process.env.CONTENTFUL_SPACE_ID,
-    CONTENTFUL_ENVIRONMENT: process.env.CONTENTFUL_ENVIRONMENT,
-    CONTENTFUL_ACCESS_TOKEN_DELIVERY:
-      process.env.CONTENTFUL_ACCESS_TOKEN_DELIVERY,
-    CONTENTFUL_ACCESS_TOKEN_PREVIEW:
-      process.env.CONTENTFUL_ACCESS_TOKEN_PREVIEW,
-    CONTENTFUL_PREVIEW: process.env.CONTENTFUL_PREVIEW,
-    SITE_DOMAIN: process.env.SITE_DOMAIN,
-  },
   nx: {
     // Set this to true if you would like to use SVGR
     // See: https://github.com/gregberge/svgr


### PR DESCRIPTION
This was creating a security issue that expose the env variables to the client bundle